### PR TITLE
Types opschonen

### DIFF
--- a/exp_parser.ml
+++ b/exp_parser.ml
@@ -162,13 +162,13 @@ atom_parser (list:tlt): (exp option result* tlt) = match list with
 	| (_,EMPTYLIST)::list -> Success (Some (Exp_emptylist)), list
 	| (_,IDtok id)::(_,OPEN_PAR)::list -> 
 		(match funcall_parser list with
-		| Success exps, list -> Success (Some (Exp_function_call ((Id id), exps))), list 
+		| Success exps, list -> Success (Some (Exp_function_call (id, exps))), list 
 		| Error e, list -> Error e, list)
 	|	(_,IDtok id)::list ->
 		(match field_parser [] list with
 		| Success fieldlist, list ->
 			(let rec packer = function
-				| [] -> (Nofield (Id id))
+				| [] -> (Nofield id)
 				| f::rest -> Field (packer rest, f) in 
 			Success (Some (Exp_field (packer fieldlist))), list)
 		| Error e, list -> Error e, list)

--- a/parser.ml
+++ b/parser.ml
@@ -12,7 +12,7 @@ open Exp_parser
 (* basictype = 'Int' | 'Bool' | 'Char' *)
 let rec type_parser = function
 	| (_,Basictoken a)::list -> Success (Basictype a),list
-	| (_,IDtok id)::list -> Success (Type_id (Id id)),list
+	| (_,IDtok id)::list -> Success (Type_id id),list
 	| (l0,OPEN_PAR)::list -> 
 		(match (type_parser list) with
 		| Success type1, (l1,COMMA)::list -> 
@@ -45,7 +45,7 @@ let rettype_parser = function
 let rec funtype_parser type_list = function
   | (_,ARROW)::list	-> 
 		(match rettype_parser list with
-  	| Success rettype, list -> Success (Funtype ((List.rev type_list), rettype)), list
+  	| Success rettype, list -> Success ((List.rev type_list), rettype), list
   	| Error e, list -> Error e, list)
   | list -> 
 		(match type_parser list with
@@ -57,7 +57,7 @@ let message = "If this is a variable declaration, you probably forgot the type o
 let vardecl_rest_parser typetoken = function
 	| (_,IDtok id)::(l0,EQ)::list -> 
 		(match exp_parser list with
-		| Success exp, (_,SEMICOLON)::list -> Success (Vardecl (typetoken, Id id, exp)), list
+		| Success exp, (_,SEMICOLON)::list -> Success (typetoken, id, exp), list
 		| Success _, (l,x)::list -> Error (sprintf "(r.%i) No semicolon, but: %s" l (token_to_string x)), (l,x)::list
 		| Success _, [] -> Error (sprintf "(r.%i) Unexpected EOF after '='." l0), []   
 		| Error e, list -> Error e, list)
@@ -135,13 +135,13 @@ stmt_parser = function
 		| Error e, list -> Error e, list)
 	| (_,IDtok id)::(_,OPEN_PAR)::list -> 
   	(match funcall_parser list with
-  	| Success exp_list, list -> Success (Stmt_function_call (Id id, exp_list)), list
+  	| Success exp_list, list -> Success (Stmt_function_call (id, exp_list)), list
 		| Error e, list -> Error e, list)
 	| (l0,IDtok id)::list ->
 		(match (field_parser [] list) with
 		| Success fieldlist, (l1,EQ)::list ->
 			(let rec packer = function
-				| [] -> (Nofield (Id id))
+				| [] -> (Nofield id)
 				| f::rest -> Field (packer rest, f) in
     	(match exp_parser list with
     	| Success exp, (_,SEMICOLON)::list ->
@@ -160,13 +160,13 @@ stmt_parser = function
 (*opgesplitst in twee functies, zodat fargs ook '()' mag zijn*)
 let fargs_parser list =
 	let rec fargs2_parser id_list = function
-		| (_,IDtok id)::(_,CLOSE_PAR)::list	-> Success (Fargs (List.rev ((Id id)::id_list))),list
-  	| (_,IDtok id)::(_,COMMA)::list -> fargs2_parser ((Id id)::id_list) list
+		| (_,IDtok id)::(_,CLOSE_PAR)::list	-> Success (List.rev  (id::id_list)),list
+  	| (_,IDtok id)::(_,COMMA)::list -> fargs2_parser (id::id_list) list
 		| (_,IDtok id)::(l,x)::list -> Error (sprintf "(r.%i) No closing parenthesis or comma, but: %s" l (token_to_string x)), (l,x)::list
 		| (l,x)::list -> Error (sprintf "(r.%i) No id, but: %s" l (token_to_string x)), (l,x)::list
 		| [] -> Error "Unexpected EOF when parsing function arguments.", []
   in match list with
-	| (_,CLOSE_PAR)::list -> Success (Fargs []), list
+	| (_,CLOSE_PAR)::list -> Success [], list
 	| list -> fargs2_parser [] list
 
 (* funDecl = fargs '(' vardeclList stmt stmtList     *)
@@ -182,7 +182,7 @@ let fundecl_parser id list = match fargs_parser list with
   		| Error e, list -> Error e, list
   		| Success [], (l,x)::list -> Error (sprintf "(r.%i) Not the beginning of a statement, but: %s" l (token_to_string x)), (l,x)::list
 			| Success [], [] -> Error (sprintf "(r.%i) Unexpected EOF after parsing opening acolade." l0), [] 
-  		| Success stmt_list, list -> Success (Fundecl (id, fargs, None, vardecl_list, stmt_list)), list))
+  		| Success stmt_list, list -> Success (id, fargs, None, vardecl_list, stmt_list), list))
   | Success fargs, (l0,DDPOINT)::list ->
     (match funtype_parser [] list with
     | Error e, list -> Error e, list
@@ -195,7 +195,7 @@ let fundecl_parser id list = match fargs_parser list with
         | Error e, list -> Error e, list
         | Success [], (l,x)::list -> Error (sprintf "(r.%i) No statement, but: %s" l (token_to_string x)), (l,x)::list
 				| Success [], [] -> Error (sprintf "(r.%i) Unexpected EOF after parsing opening acolade." l0), [] 
-        | Success stmt_list, list -> Success (Fundecl (id, fargs, Some funtype, vardecl_list, stmt_list)), list))
+        | Success stmt_list, list -> Success (id, fargs, Some funtype, vardecl_list, stmt_list), list))
 		| Success _, (l,x)::list -> Error (sprintf "(r.%i) No opening acolade, but: %s" l (token_to_string x)), (l,x)::list
 		| Success _, [] -> Error (sprintf "(r.%i) Unexpected EOF after parsing '::'." l0), [])
 	| Success _, (l,x)::list -> Error (sprintf "(r.%i) No opening parenthesis or '::', but: %s" l (token_to_string x)), (l,x)::list
@@ -204,18 +204,18 @@ let fundecl_parser id list = match fargs_parser list with
 (* Decl = id '('  FunDecl | VarDecl *)
 let decl_parser = function
 	| (_,IDtok id)::(_,OPEN_PAR)::list ->
-		(match fundecl_parser (Id id) list with
-		| Success fundecl, list -> Success (Decl_fun fundecl), list
+		(match fundecl_parser id list with
+		| Success fundecl, list -> Success (Fundecl fundecl), list
 		| Error e, faillist -> Error e, faillist)
 	| (l,IDtok id)::[] -> Error (sprintf "(r.%i) Unexpected EOF after parsing id.\nBy the way: is '%s' a type for a variable, or a function name without arguments?" l id), []
 	| list -> 
 		(match vardecl_parser list with
-		| Success vardecl, list -> Success (Decl_var vardecl), list
+		| Success vardecl, list -> Success (Vardecl vardecl), list
 		| Error e, faillist -> Error e, faillist);;
 
 (* SPL = Decl+ *)
 let rec spl_parser decllist tokenlist = 
 	match decl_parser tokenlist with
-  | Success decls, [] -> Success (SPL (List.rev (decls::decllist)))
+  | Success decls, [] -> Success  (List.rev (decls::decllist))
   | Success decls, list -> spl_parser (decls::decllist) list
   | Error e, list -> Error e;;

--- a/pretty_printer_files.ml
+++ b/pretty_printer_files.ml
@@ -10,7 +10,7 @@ let print_bool ppf = function
 
 (* print de string van een Id *)
 let print_id ppf = function
-	| Id id -> fprintf ppf "%s" id;;
+	| id -> fprintf ppf "%s" id;;
 
 (* print de operator van een Op1 *)
 let print_op1 ppf = function
@@ -115,11 +115,11 @@ and print_funcall ppf = function
 
 (* Print een lijst van function arguments *)
 let rec print_fargs ppf = function
-	| Fargs [] -> ()
-	| Fargs [a] ->
+	| [] -> ()
+	| [a] ->
 		fprintf ppf "%a" print_id a;
-	| Fargs (a::list) ->
-		fprintf ppf "%a, %a" print_id a print_fargs (Fargs list);;
+	| (a::list) ->
+		fprintf ppf "%a, %a" print_id a print_fargs list;;
 
 (* Print basictypes int, bool of char *)
 let print_basictype ppf = function
@@ -141,8 +141,8 @@ let print_rettype ppf = function
 
 (* Print een functietype *)
 let rec print_funtype ppf = function
-	| Funtype ([], ret) -> fprintf ppf "-> %a " print_rettype ret;
-	| Funtype (a::list, ret) -> fprintf ppf "%a %a" print_typetoken a print_funtype (Funtype (list, ret));;
+	| ([], ret) -> fprintf ppf "-> %a " print_rettype ret;
+	| (a::list, ret) -> fprintf ppf "%a %a" print_typetoken a print_funtype (list, ret);;
 
 (* Nodig omdat een vardecl ofwel 'var' heeft, ofwel een type *)
 let print_var_option ppf = function
@@ -150,7 +150,7 @@ let print_var_option ppf = function
 	| Some t -> fprintf ppf "%a" print_typetoken t;;
 
 let rec print_vardecl ppf = function
-	| Vardecl (t, id, exp) -> fprintf ppf "%a %a = %a;" print_var_option t print_id id print_exp exp;;
+	| (t, id, exp) -> fprintf ppf "%a %a = %a;" print_var_option t print_id id print_exp exp;;
 
 let rec print_vardecl_list ppf = function
 	| [] -> ();
@@ -161,13 +161,13 @@ let print_funtype_option ppf = function
 	| Some ft -> fprintf ppf " :: %a" print_funtype ft;;
 
 let rec print_fundecl ppf = function
-	| Fundecl (id, fargs, funtype, vardecl_list, stmt_list) -> 
+	| (id, fargs, funtype, vardecl_list, stmt_list) -> 
 		fprintf ppf "%a(%a)%a{@;<0 2>@[<v 0>%a%a@]@,}" print_id id print_fargs fargs print_funtype_option funtype print_vardecl_list vardecl_list print_stmt_list stmt_list;;
 
 let print_decl ppf = function
-	| Decl_var v -> fprintf ppf "%a" print_vardecl v;
-	| Decl_fun f -> fprintf ppf "%a" print_fundecl f;;
+	| Vardecl v -> fprintf ppf "%a" print_vardecl v;
+	| Fundecl f -> fprintf ppf "%a" print_fundecl f;;
 
 let rec print_spl ppf = function
-	| SPL [] -> ();
-	| SPL (x::list) -> fprintf ppf "@[<v 0>%a@]@.@.%a" print_decl x print_spl (SPL list);;
+	| [] -> ();
+	| (x::list) -> fprintf ppf "@[<v 0>%a@]@.@.%a" print_decl x print_spl list;;

--- a/types.ml
+++ b/types.ml
@@ -1,5 +1,5 @@
 (*==    structure    ==*)
-type id = Id of string
+type id = string
 type op1 = Not | Neg
 type logop = And | Or
 type eqop = Eq | Neq
@@ -34,18 +34,18 @@ type stmt =
 	| Stmt_define of fieldexp * exp
 	| Stmt_function_call of id *  exp list
 	| Stmt_return of exp option
-type fargs = Fargs of id list
+type fargs = id list
 type basictype = Type_int | Type_bool | Type_char
 type typetoken =  Basictype of basictype
 	| Type_tuple of typetoken * typetoken
 	| Type_list of typetoken
 	| Type_id of id
 type rettype = Rettype of typetoken | Type_void
-type funtype = Funtype of typetoken list * rettype
-type vardecl = Vardecl of typetoken option * id * exp 
-type fundecl = Fundecl of id * fargs * funtype option * vardecl list * stmt list
-type decl = Decl_var of vardecl | Decl_fun of fundecl
-type spl = SPL of decl list;;
+type funtype = typetoken list * rettype
+type vardecl = typetoken option * id * exp 
+type fundecl = id * fargs * funtype option * vardecl list * stmt list
+type decl = Vardecl of vardecl | Fundecl of fundecl
+type spl = decl list;;
 
 
 (*==    result    ==*)


### PR DESCRIPTION
het blijkt dat blauwe tekst niet nodig is als er geen | voorkomt in de type. Alle code is nu een stuk mooier en korter
